### PR TITLE
Route logging to handled-errors.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/4b1449f7-689f-49f6-b7ca-310cffd80a0c" />
 
 
-Production-ready mitigation plugin that ensures zMenu GUI sessions are closed safely when the zMenu plugin reloads or shuts down. Built for Paper/Spigot 1.20.1+ with configuration-driven behaviour and structured file logging.
+Production-ready mitigation plugin that ensures zMenu GUI sessions are closed safely when the zMenu plugin reloads or shuts down. Built for Paper/Spigot 1.20.1+ with configuration-driven behaviour and structured XML logging.
 
 ## Features
 - Gracefully detects zMenu enable/disable lifecycle without a hard dependency.
 - Closes lingering inventory views on zMenu disable to prevent `IllegalPluginAccessException`.
 - Optional player notifications, debug instrumentation, and async guards for thread safety.
-- Daily-rotating file logs stored under `plugins/ZMenuFix/logs` with optional stack traces.
+- Structured XML log stream written to `plugins/ZMenuFix/handled-errors.xml` with optional stack traces.
 
 ## Configuration
 Configuration is stored at `plugins/ZMenuFix/config.yml`:
@@ -20,8 +20,7 @@ enabled: true
 debug: false
 log:
   enabled: true
-  folder: logs
-  rotate_daily: true
+  file: handled-errors.xml
   include_stacktraces: false
 fix:
   close_on_zmenu_disable: true

--- a/src/java/dev/quantumfusion/zmenufix/config/ZMenuFixConfiguration.java
+++ b/src/java/dev/quantumfusion/zmenufix/config/ZMenuFixConfiguration.java
@@ -38,22 +38,19 @@ public final class ZMenuFixConfiguration {
     public static final class LoggingSettings {
 
         private final boolean enabled;
-        private final String folder;
-        private final boolean rotateDaily;
+        private final String file;
         private final boolean includeStacktraces;
 
         public LoggingSettings(ConfigurationSection section) {
             if (section == null) {
                 this.enabled = true;
-                this.folder = "logs";
-                this.rotateDaily = true;
+                this.file = "handled-errors.xml";
                 this.includeStacktraces = false;
                 return;
             }
 
             this.enabled = section.getBoolean("enabled", true);
-            this.folder = section.getString("folder", "logs");
-            this.rotateDaily = section.getBoolean("rotate_daily", true);
+            this.file = section.getString("file", "handled-errors.xml");
             this.includeStacktraces = section.getBoolean("include_stacktraces", false);
         }
 
@@ -61,12 +58,8 @@ public final class ZMenuFixConfiguration {
             return enabled;
         }
 
-        public String folder() {
-            return folder;
-        }
-
-        public boolean rotateDaily() {
-            return rotateDaily;
+        public String file() {
+            return file;
         }
 
         public boolean includeStacktraces() {

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -2,8 +2,7 @@ enabled: true
 debug: false
 log:
   enabled: true
-  folder: logs
-  rotate_daily: true
+  file: handled-errors.xml
   include_stacktraces: false
 fix:
   close_on_zmenu_disable: true


### PR DESCRIPTION
## Summary
- document the ZMFIX XML logging configuration in the README and default config
- update configuration parsing to target a single handled-errors.xml log file
- rewrite the logger to emit XML entries into handled-errors.xml instead of rotating text logs

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dee9243d448320860892ebefdf7fd9