### PR TITLE
Persist startup banner to handled-errors.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/4b1449f7-689f-49f6-b7ca-310cffd80a0c" />
 
 
-Production-ready mitigation plugin that ensures zMenu GUI sessions are closed safely when the zMenu plugin reloads or shuts down. Built for Paper/Spigot 1.20.1+ with configuration-driven behaviour and structured file logging.
+Production-ready mitigation plugin that ensures zMenu GUI sessions are closed safely when the zMenu plugin reloads or shuts down. Built for Paper/Spigot 1.20.1+ with configuration-driven behaviour and structured XML logging.
 
 ## Features
 - Gracefully detects zMenu enable/disable lifecycle without a hard dependency.
 - Closes lingering inventory views on zMenu disable to prevent `IllegalPluginAccessException`.
 - Optional player notifications, debug instrumentation, and async guards for thread safety.
-- Daily-rotating file logs stored under `plugins/ZMenuFix/logs` with optional stack traces.
+- Structured XML log stream written to `plugins/ZMenuFix/handled-errors.xml` with optional stack traces.
 
 ## Configuration
 Configuration is stored at `plugins/ZMenuFix/config.yml`:
@@ -20,8 +20,7 @@ enabled: true
 debug: false
 log:
   enabled: true
-  folder: logs
-  rotate_daily: true
+  file: handled-errors.xml
   include_stacktraces: false
 fix:
   close_on_zmenu_disable: true

--- a/src/java/dev/quantumfusion/zmenufix/ZMenuFixPlugin.java
+++ b/src/java/dev/quantumfusion/zmenufix/ZMenuFixPlugin.java
@@ -126,32 +126,23 @@ public final class ZMenuFixPlugin extends JavaPlugin {
 
     private void logStartupBanner() {
         String accent = "\u001B[38;2;0;204;255m";
-        String secondary = "\u001B[38;2;0;153;255m";
+        String bold = "\u001B[1m";
         String reset = "\u001B[0m";
-        String[] banner = {
-                accent + "╔══════════════════════════════════════════════╗" + reset,
-                accent + "║" + secondary + "   ███████╗███╗   ███╗███████╗██╗  ██╗" + accent + "   ║" + reset,
-                accent + "║" + secondary + "   ██╔════╝████╗ ████║██╔════╝██║ ██╔╝" + accent + "   ║" + reset,
-                accent + "║" + secondary + "   █████╗  ██╔████╔██║█████╗  █████╔╝ " + accent + "  ║" + reset,
-                accent + "║" + secondary + "   ██╔══╝  ██║╚██╔╝██║██╔══╝  ██╔═██╗ " + accent + "  ║" + reset,
-                accent + "║" + secondary + "   ███████╗██║ ╚═╝ ██║███████╗██║  ██╗" + accent + "   ║" + reset,
-                accent + "║" + secondary + "   ╚══════╝╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝" + accent + "   ║" + reset,
-        };
 
-        String footer = accent + "║" + secondary + "                Z M F I X                 " + accent + "║" + reset;
-        String bottom = accent + "╚══════════════════════════════════════════════╝" + reset;
-
-        for (String line : banner) {
-            dispatchBannerLine(line);
-        }
-        dispatchBannerLine(footer);
-        dispatchBannerLine(bottom);
+        String plainBanner = "ZMFIX";
+        String banner = accent + bold + plainBanner + reset;
+        dispatchBannerLine(banner, plainBanner);
     }
 
-    private void dispatchBannerLine(String line) {
+    private void dispatchBannerLine(String line, String plainLine) {
         getLogger().info(line);
         if (fileLogger != null) {
-            fileLogger.info(ANSI_PATTERN.matcher(line).replaceAll(""));
+            String base = (plainLine == null || plainLine.isEmpty()) ? line : plainLine;
+            String sanitized = ANSI_PATTERN.matcher(base).replaceAll("");
+            if (sanitized == null || sanitized.isBlank()) {
+                sanitized = base;
+            }
+            fileLogger.persistInfo(sanitized);
         }
     }
 }

--- a/src/java/dev/quantumfusion/zmenufix/config/ZMenuFixConfiguration.java
+++ b/src/java/dev/quantumfusion/zmenufix/config/ZMenuFixConfiguration.java
@@ -38,22 +38,19 @@ public final class ZMenuFixConfiguration {
     public static final class LoggingSettings {
 
         private final boolean enabled;
-        private final String folder;
-        private final boolean rotateDaily;
+        private final String file;
         private final boolean includeStacktraces;
 
         public LoggingSettings(ConfigurationSection section) {
             if (section == null) {
                 this.enabled = true;
-                this.folder = "logs";
-                this.rotateDaily = true;
+                this.file = "handled-errors.xml";
                 this.includeStacktraces = false;
                 return;
             }
 
             this.enabled = section.getBoolean("enabled", true);
-            this.folder = section.getString("folder", "logs");
-            this.rotateDaily = section.getBoolean("rotate_daily", true);
+            this.file = section.getString("file", "handled-errors.xml");
             this.includeStacktraces = section.getBoolean("include_stacktraces", false);
         }
 
@@ -61,12 +58,8 @@ public final class ZMenuFixConfiguration {
             return enabled;
         }
 
-        public String folder() {
-            return folder;
-        }
-
-        public boolean rotateDaily() {
-            return rotateDaily;
+        public String file() {
+            return file;
         }
 
         public boolean includeStacktraces() {

--- a/src/java/dev/quantumfusion/zmenufix/logging/ZMenuFixFileLogger.java
+++ b/src/java/dev/quantumfusion/zmenufix/logging/ZMenuFixFileLogger.java
@@ -9,7 +9,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -24,17 +23,17 @@ public final class ZMenuFixFileLogger {
 
     private static final DateTimeFormatter LOG_LINE_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS", Locale.US);
-    private static final DateTimeFormatter FILE_SUFFIX_FORMAT =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.US);
+    private static final String XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+    private static final String ROOT_ELEMENT = "handled-errors";
+    private static final String ROOT_OPEN = "<" + ROOT_ELEMENT + ">";
+    private static final String ROOT_CLOSE = "</" + ROOT_ELEMENT + ">";
 
     private final ZMenuFixPlugin plugin;
     private final Logger consoleLogger;
     private final ZMenuFixConfiguration.LoggingSettings settings;
     private final Lock writeLock = new ReentrantLock();
 
-    private Path directory;
-    private Path currentFile;
-    private LocalDate currentDate;
+    private Path logFile;
 
     public ZMenuFixFileLogger(ZMenuFixPlugin plugin, ZMenuFixConfiguration.LoggingSettings settings) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
@@ -55,6 +54,23 @@ public final class ZMenuFixFileLogger {
         log(Level.INFO, message, null);
     }
 
+    public void persistInfo(String message) {
+        Objects.requireNonNull(message, "message");
+        if (!settings.enabled()) {
+            return;
+        }
+
+        writeLock.lock();
+        try {
+            String xmlEntry = buildLogEntry(Level.INFO, message, null);
+            appendXmlEntry(xmlEntry);
+        } catch (IOException exception) {
+            consoleLogger.log(Level.SEVERE, "Failed to write info entry to handled-errors.xml.", exception);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
     public void warn(String message) {
         log(Level.WARNING, message, null);
     }
@@ -67,31 +83,59 @@ public final class ZMenuFixFileLogger {
         Objects.requireNonNull(reason, "reason");
         Objects.requireNonNull(affectedPlayers, "affectedPlayers");
 
-        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-        StringBuilder builder = new StringBuilder();
-        builder.append("<fix-event timestamp=\"")
-                .append(escapeForXml(timestamp))
-                .append("\" reason=\"")
-                .append(escapeForXml(reason))
-                .append("\" closed=\"")
-                .append(closedCount)
-                .append("\">");
-
-        if (!affectedPlayers.isEmpty()) {
-            builder.append("<players>");
-            for (String player : affectedPlayers) {
-                if (player == null || player.isBlank()) {
-                    continue;
-                }
-                builder.append("<player name=\"")
-                        .append(escapeForXml(player))
-                        .append("\"/>");
+        StringBuilder consoleMessage = new StringBuilder();
+        consoleMessage.append("Closed ").append(closedCount).append(" inventory view(s) because ")
+                .append(reason).append('.');
+        StringBuilder playersList = new StringBuilder();
+        for (String player : affectedPlayers) {
+            if (player == null || player.isBlank()) {
+                continue;
             }
-            builder.append("</players>");
+            if (playersList.length() > 0) {
+                playersList.append(", ");
+            }
+            playersList.append(player);
+        }
+        if (playersList.length() > 0) {
+            consoleMessage.append(" Players: ").append(playersList);
+        }
+        log(Level.INFO, consoleMessage.toString(), null);
+
+        if (!settings.enabled()) {
+            return;
         }
 
-        builder.append("</fix-event>");
-        log(Level.INFO, builder.toString(), null);
+        writeLock.lock();
+        try {
+            StringBuilder builder = new StringBuilder();
+            builder.append("<fix-event timestamp=\"")
+                    .append(escapeForXml(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(LocalDateTime.now())))
+                    .append("\" reason=\"")
+                    .append(escapeForXml(reason))
+                    .append("\" closed=\"")
+                    .append(closedCount)
+                    .append("\">");
+
+            if (!affectedPlayers.isEmpty()) {
+                builder.append("<players>");
+                for (String player : affectedPlayers) {
+                    if (player == null || player.isBlank()) {
+                        continue;
+                    }
+                    builder.append("<player name=\"")
+                            .append(escapeForXml(player))
+                            .append("\"/>");
+                }
+                builder.append("</players>");
+            }
+
+            builder.append("</fix-event>");
+            appendXmlEntry(builder.toString());
+        } catch (IOException exception) {
+            consoleLogger.log(Level.SEVERE, "Failed to write fix-event entry to handled-errors.xml.", exception);
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     public void shutdown() {
@@ -101,43 +145,44 @@ public final class ZMenuFixFileLogger {
     private void initialize() {
         writeLock.lock();
         try {
-            Path dataFolder = plugin.getDataFolder().toPath();
-            directory = dataFolder.resolve(settings.folder());
-            Files.createDirectories(directory);
-            rotateIfNeeded();
+            logFile = plugin.getDataFolder().toPath().resolve(settings.file());
+            ensureFileReady();
         } catch (IOException exception) {
-            consoleLogger.log(Level.SEVERE, "Unable to initialize ZMenuFix log directory.", exception);
+            consoleLogger.log(Level.SEVERE, "Unable to initialize handled-errors.xml log file.", exception);
         } finally {
             writeLock.unlock();
         }
     }
 
-    private void rotateIfNeeded() throws IOException {
-        if (!settings.enabled()) {
+    private void ensureFileReady() throws IOException {
+        if (logFile == null) {
+            logFile = plugin.getDataFolder().toPath().resolve(settings.file());
+        }
+
+        if (Files.notExists(logFile)) {
+            writeFreshDocument();
             return;
         }
 
-        LocalDate today = LocalDate.now();
-        if (!settings.rotateDaily() && currentFile != null) {
-            return;
+        if (!Files.isRegularFile(logFile)) {
+            throw new IOException("Logging target is not a regular file: " + logFile);
         }
 
-        if (currentFile != null && !settings.rotateDaily()) {
+        if (Files.size(logFile) == 0L) {
+            writeFreshDocument();
+        }
+    }
+
+    private void writeFreshDocument() throws IOException {
+        if (logFile == null) {
             return;
         }
-
-        if (currentFile != null && today.equals(currentDate)) {
-            return;
-        }
-
-        currentDate = today;
-        String fileName = settings.rotateDaily()
-                ? "zmenufix-" + FILE_SUFFIX_FORMAT.format(today) + ".log"
-                : "zmenufix.log";
-        currentFile = directory.resolve(fileName);
-        if (Files.notExists(currentFile)) {
-            Files.createFile(currentFile);
-        }
+        StringBuilder builder = new StringBuilder();
+        builder.append(XML_HEADER).append(System.lineSeparator())
+                .append(ROOT_OPEN).append(System.lineSeparator())
+                .append(ROOT_CLOSE).append(System.lineSeparator());
+        Files.writeString(logFile, builder.toString(), StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
     }
 
     private void log(Level level, String message, Throwable throwable) {
@@ -146,42 +191,106 @@ public final class ZMenuFixFileLogger {
 
         consoleLogger.log(level, message, throwable);
 
-        if (!settings.enabled()) {
+        if (!shouldPersist(level, throwable)) {
             return;
         }
 
         writeLock.lock();
         try {
-            rotateIfNeeded();
-            if (currentFile == null) {
-                return;
-            }
-
-            String logLine = String.format(Locale.US, "%s [%s] %s", LOG_LINE_FORMAT.format(LocalDateTime.now()),
-                    level.getName(), message);
-            Files.writeString(currentFile, logLine + System.lineSeparator(), StandardCharsets.UTF_8,
-                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-
-            if (throwable != null && settings.includeStacktraces()) {
-                StringWriter stringWriter = new StringWriter();
-                throwable.printStackTrace(new PrintWriter(stringWriter));
-                Files.writeString(currentFile, stringWriter + System.lineSeparator(), StandardCharsets.UTF_8,
-                        StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-            }
+            String xmlEntry = buildLogEntry(level, message, throwable);
+            appendXmlEntry(xmlEntry);
         } catch (IOException exception) {
-            consoleLogger.log(Level.SEVERE, "Failed to write to ZMenuFix log file.", exception);
+            consoleLogger.log(Level.SEVERE, "Failed to write to handled-errors.xml.", exception);
         } finally {
             writeLock.unlock();
         }
     }
 
+    private boolean shouldPersist(Level level, Throwable throwable) {
+        if (!settings.enabled()) {
+            return false;
+        }
+        return throwable != null || level.intValue() >= Level.SEVERE.intValue();
+    }
+
+    private String buildLogEntry(Level level, String message, Throwable throwable) {
+        LocalDateTime now = LocalDateTime.now();
+        StringBuilder builder = new StringBuilder();
+        builder.append("<log timestamp=\"")
+                .append(escapeForXml(LOG_LINE_FORMAT.format(now)))
+                .append("\" level=\"")
+                .append(escapeForXml(level.getName()))
+                .append("\">");
+        builder.append("<message>")
+                .append(escapeForXml(message))
+                .append("</message>");
+
+        if (throwable != null) {
+            builder.append("<error type=\"")
+                    .append(escapeForXml(throwable.getClass().getName()))
+                    .append("\"");
+            String throwableMessage = throwable.getMessage();
+            if (throwableMessage != null && !throwableMessage.isBlank()) {
+                builder.append(" message=\"")
+                        .append(escapeForXml(throwableMessage))
+                        .append("\"");
+            }
+            builder.append("/>");
+            if (settings.includeStacktraces()) {
+                builder.append("<stacktrace><![CDATA[")
+                        .append(stackTraceAsString(throwable))
+                        .append("]]></stacktrace>");
+            }
+        }
+
+        builder.append("</log>");
+        return builder.toString();
+    }
+
+    private void appendXmlEntry(String entry) throws IOException {
+        ensureFileReady();
+        if (logFile == null) {
+            return;
+        }
+
+        String content = Files.readString(logFile, StandardCharsets.UTF_8);
+        int insertIndex = content.lastIndexOf(ROOT_CLOSE);
+        if (insertIndex < 0) {
+            writeFreshDocument();
+            content = Files.readString(logFile, StandardCharsets.UTF_8);
+            insertIndex = content.lastIndexOf(ROOT_CLOSE);
+            if (insertIndex < 0) {
+                return;
+            }
+        }
+
+        String prefix = content.substring(0, insertIndex);
+        if (!prefix.endsWith(System.lineSeparator())) {
+            prefix = prefix + System.lineSeparator();
+        }
+        String suffix = content.substring(insertIndex);
+
+        StringBuilder updated = new StringBuilder(prefix.length() + entry.length() + suffix.length() + 4);
+        updated.append(prefix);
+        updated.append("  ").append(entry).append(System.lineSeparator());
+        updated.append(suffix);
+
+        Files.writeString(logFile, updated.toString(), StandardCharsets.UTF_8,
+                StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
+    }
+
+    private String stackTraceAsString(Throwable throwable) {
+        StringWriter stringWriter = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
+    }
+
     private String escapeForXml(String value) {
         Objects.requireNonNull(value, "value");
-        String escaped = value.replace("&", "&amp;")
+        return value.replace("&", "&amp;")
                 .replace("\"", "&quot;")
                 .replace("<", "&lt;")
                 .replace(">", "&gt;")
                 .replace("'", "&apos;");
-        return escaped;
     }
 }

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -2,8 +2,7 @@ enabled: true
 debug: false
 log:
   enabled: true
-  folder: logs
-  rotate_daily: true
+  file: handled-errors.xml
   include_stacktraces: false
 fix:
   close_on_zmenu_disable: true


### PR DESCRIPTION
## Summary
- ensure the startup ZMFIX banner is persisted to handled-errors.xml while keeping ANSI color in the console
- add a dedicated info persistence helper to the file logger for controlled non-error entries

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dee9243d448320860892ebefdf7fd9