### PR TITLE
Fix compilation error in BannerGlyph helper

### DIFF
--- a/src/java/dev/quantumfusion/zmenufix/ZMenuFixPlugin.java
+++ b/src/java/dev/quantumfusion/zmenufix/ZMenuFixPlugin.java
@@ -213,6 +213,5 @@ public final class ZMenuFixPlugin extends JavaPlugin {
             }
             return String.format("%-" + width + "s", value);
         }
-        getLogger().info(sanitized);
     }
 }


### PR DESCRIPTION
## Summary
- remove an erroneous logger call that was placed outside of any method in `ZMenuFixPlugin`
- restore valid syntax for the inner `BannerGlyph` class so the project compiles again

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68df00ff8690832092c9a32a4bbbb928