### PR TITLE
Prevent scheduling tasks after plugin disable

### DIFF
--- a/src/java/dev/quantumfusion/zmenufix/ZMenuFixPlugin.java
+++ b/src/java/dev/quantumfusion/zmenufix/ZMenuFixPlugin.java
@@ -114,11 +114,17 @@ public final class ZMenuFixPlugin extends JavaPlugin {
     public void executeOnPrimaryThread(Runnable task) {
         Objects.requireNonNull(task, "task");
         boolean shouldGuard = configuration != null && configuration.fix().asyncGuard();
-        if (shouldGuard && !Bukkit.isPrimaryThread()) {
-            Bukkit.getScheduler().runTask(this, task);
-        } else {
+        if (!shouldGuard || Bukkit.isPrimaryThread()) {
             task.run();
+            return;
         }
+
+        if (!isEnabled()) {
+            task.run();
+            return;
+        }
+
+        Bukkit.getScheduler().runTask(this, task);
     }
 
     public boolean isDebug() {


### PR DESCRIPTION
## Summary
- guard the primary-thread scheduler helper against running when the plugin is disabled
- run tasks inline when already on the server thread to avoid unnecessary scheduling

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68dfd62de08483209ba9471f91019d1b